### PR TITLE
feat: add message options to create command

### DIFF
--- a/lib/src/commands/command_base.dart
+++ b/lib/src/commands/command_base.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:args/command_runner.dart';
 import 'package:dependabot_gen/src/dependabot_yaml/dependabot_yaml.dart';
+import 'package:dependabot_gen/src/dependabot_yaml/spec.dart';
 import 'package:dependabot_gen/src/package_ecosystem/package_ecosystem.dart';
 import 'package:git/git.dart';
 import 'package:mason_logger/mason_logger.dart';
@@ -251,6 +252,56 @@ mixin GroupsOption on CommandBase {
 
   /// Whether to use groups.
   bool get useGroups => argResults!['use-groups'] as bool;
+}
+
+/// Adds the `--commit-message-prefix`, `--commit-message-prefix-development`,
+/// and `--commit-message-include` options to the command.
+mixin CommitMessageOption on CommandBase {
+  @override
+  void addOptions() {
+    super.addOptions();
+    argParser
+      ..addOption(
+        'commit-message-prefix',
+        help: 'Prefix for all commit messages and pull request titles. ',
+      )
+      ..addOption(
+        'commit-message-prefix-development',
+        help: 'Prefix used only for commit messages that update dependencies '
+            'in the Development dependency group. Supported by: bundler, '
+            'composer, mix, maven, npm, pip, and uv. Behaves like '
+            '--commit-message-prefix for all other cases.',
+      )
+      ..addOption(
+        'commit-message-include',
+        allowed: CommitMessageInclude.values.map((e) => e.name),
+        help: 'Follow the commit message prefix with additional information. '
+            'Currently only "scope" is supported, which appends the type of '
+            'dependencies updated in the commit: deps or deps-dev.',
+      );
+  }
+
+  /// Gets the [CommitMessage] for the command, or `null` if none was provided.
+  CommitMessage? get commitMessage {
+    final prefix = argResults!['commit-message-prefix'] as String?;
+    final prefixDevelopment =
+        argResults!['commit-message-prefix-development'] as String?;
+    final includeRaw = argResults!['commit-message-include'] as String?;
+
+    if (prefix == null && prefixDevelopment == null && includeRaw == null) {
+      return null;
+    }
+
+    final include = includeRaw == null
+        ? null
+        : CommitMessageInclude.values.firstWhere((e) => e.name == includeRaw);
+
+    return CommitMessage(
+      prefix: prefix,
+      prefixDevelopment: prefixDevelopment,
+      include: include,
+    );
+  }
 }
 
 /// Adds the `--ecosystems` option to the command.

--- a/lib/src/commands/create_command.dart
+++ b/lib/src/commands/create_command.dart
@@ -17,6 +17,7 @@ class CreateCommand extends CommandBase
         LabelsOption,
         MilestoneOption,
         GroupsOption,
+        CommitMessageOption,
         IgnorePathsOption,
         RepositoryRootOption {
   /// {@macro create_command}
@@ -80,6 +81,7 @@ Create or update the dependabot.yaml file in a repository. Will keep existing en
                 targetBranch: targetBranch,
                 labels: labels,
                 milestone: milestone,
+                commitMessage: commitMessage,
                 groups: useGroups
                     ? {
                         e.groupName: const {

--- a/lib/src/dependabot_yaml/spec.dart
+++ b/lib/src/dependabot_yaml/spec.dart
@@ -427,8 +427,8 @@ class CommitMessage extends Equatable {
   final String? prefixDevelopment;
 
   /// The scope to use for commit messages.
-  @JsonKey(defaultValue: 'scope', disallowNullValue: true)
-  final String? include;
+  @JsonKey(defaultValue: CommitMessageInclude.scope, disallowNullValue: true)
+  final CommitMessageInclude? include;
 
   @override
   List<Object?> get props => [
@@ -565,4 +565,11 @@ enum InsecureExternalCodeExecution {
   /// Deny code execution in manifest files.
   @JsonValue('deny')
   deny,
+}
+
+/// Follow the commit message prefix with additional information.
+enum CommitMessageInclude {
+  /// Include the scope of the update in the commit message: deps or deps-dev.
+  @JsonValue('scope')
+  scope,
 }

--- a/lib/src/dependabot_yaml/spec.g.dart
+++ b/lib/src/dependabot_yaml/spec.g.dart
@@ -54,23 +54,15 @@ DependabotSpec _$DependabotSpecFromJson(Map json) => $checkedCreate(
       fieldKeyMap: const {'enableBetaEcosystems': 'enable-beta-ecosystems'},
     );
 
-Map<String, dynamic> _$DependabotSpecToJson(DependabotSpec instance) {
-  final val = <String, dynamic>{
-    'version': _$DependabotVersionEnumMap[instance.version]!,
-  };
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('enable-beta-ecosystems', instance.enableBetaEcosystems);
-  writeNotNull('ignore', _ignoresToJson(instance.ignore));
-  writeNotNull('registries', instance.registries);
-  val['updates'] = _updatesToJson(instance.updates);
-  return val;
-}
+Map<String, dynamic> _$DependabotSpecToJson(DependabotSpec instance) =>
+    <String, dynamic>{
+      'version': _$DependabotVersionEnumMap[instance.version]!,
+      if (instance.enableBetaEcosystems case final value?)
+        'enable-beta-ecosystems': value,
+      if (_ignoresToJson(instance.ignore) case final value?) 'ignore': value,
+      if (instance.registries case final value?) 'registries': value,
+      'updates': _updatesToJson(instance.updates),
+    };
 
 const _$DependabotVersionEnumMap = {
   DependabotVersion.v2: 2,
@@ -186,44 +178,39 @@ UpdateEntry _$UpdateEntryFromJson(Map json) => $checkedCreate(
       },
     );
 
-Map<String, dynamic> _$UpdateEntryToJson(UpdateEntry instance) {
-  final val = <String, dynamic>{
-    'package-ecosystem': instance.ecosystem,
-    'directory': instance.directory,
-    'schedule': instance.schedule.toJson(),
-  };
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('allow',
-      instance.allow?.map(const _AllowedEntryConverter().toJson).toList());
-  writeNotNull('assignees', instance.assignees?.toList());
-  writeNotNull('commit-message', instance.commitMessage?.toJson());
-  writeNotNull('groups', instance.groups);
-  writeNotNull('ignore', _ignoresToJson(instance.ignore));
-  writeNotNull(
-      'insecure-external-code-execution',
-      _$InsecureExternalCodeExecutionEnumMap[
-          instance.insecureExternalCodeExecution]);
-  writeNotNull('labels', instance.labels?.toList());
-  writeNotNull('milestone', instance.milestone);
-  writeNotNull('open-pull-requests-limit', instance.openPullRequestsLimit);
-  writeNotNull(
-      'pull-request-branch-name', instance.pullRequestBranchName?.toJson());
-  writeNotNull(
-      'rebase-strategy', _$RebaseStrategyEnumMap[instance.rebaseStrategy]);
-  writeNotNull('registries', instance.registries);
-  writeNotNull('reviewers', instance.reviewers);
-  writeNotNull('target-branch', instance.targetBranch);
-  writeNotNull('vendor', instance.vendor);
-  writeNotNull('versioning-strategy',
-      _$VersioningStrategyEnumMap[instance.versioningStrategy]);
-  return val;
-}
+Map<String, dynamic> _$UpdateEntryToJson(UpdateEntry instance) =>
+    <String, dynamic>{
+      'package-ecosystem': instance.ecosystem,
+      'directory': instance.directory,
+      'schedule': instance.schedule.toJson(),
+      if (instance.allow?.map(const _AllowedEntryConverter().toJson).toList()
+          case final value?)
+        'allow': value,
+      if (instance.assignees?.toList() case final value?) 'assignees': value,
+      if (instance.commitMessage?.toJson() case final value?)
+        'commit-message': value,
+      if (instance.groups case final value?) 'groups': value,
+      if (_ignoresToJson(instance.ignore) case final value?) 'ignore': value,
+      if (_$InsecureExternalCodeExecutionEnumMap[
+              instance.insecureExternalCodeExecution]
+          case final value?)
+        'insecure-external-code-execution': value,
+      if (instance.labels?.toList() case final value?) 'labels': value,
+      if (instance.milestone case final value?) 'milestone': value,
+      if (instance.openPullRequestsLimit case final value?)
+        'open-pull-requests-limit': value,
+      if (instance.pullRequestBranchName?.toJson() case final value?)
+        'pull-request-branch-name': value,
+      if (_$RebaseStrategyEnumMap[instance.rebaseStrategy] case final value?)
+        'rebase-strategy': value,
+      if (instance.registries case final value?) 'registries': value,
+      if (instance.reviewers case final value?) 'reviewers': value,
+      if (instance.targetBranch case final value?) 'target-branch': value,
+      if (instance.vendor case final value?) 'vendor': value,
+      if (_$VersioningStrategyEnumMap[instance.versioningStrategy]
+          case final value?)
+        'versioning-strategy': value,
+    };
 
 const _$InsecureExternalCodeExecutionEnumMap = {
   InsecureExternalCodeExecution.allow: 'allow',
@@ -265,22 +252,12 @@ Schedule _$ScheduleFromJson(Map json) => $checkedCreate(
       },
     );
 
-Map<String, dynamic> _$ScheduleToJson(Schedule instance) {
-  final val = <String, dynamic>{
-    'interval': _$ScheduleIntervalEnumMap[instance.interval]!,
-  };
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('day', _$ScheduleDayEnumMap[instance.day]);
-  writeNotNull('time', instance.time);
-  writeNotNull('timezone', instance.timezone);
-  return val;
-}
+Map<String, dynamic> _$ScheduleToJson(Schedule instance) => <String, dynamic>{
+      'interval': _$ScheduleIntervalEnumMap[instance.interval]!,
+      if (_$ScheduleDayEnumMap[instance.day] case final value?) 'day': value,
+      if (instance.time case final value?) 'time': value,
+      if (instance.timezone case final value?) 'timezone': value,
+    };
 
 const _$ScheduleIntervalEnumMap = {
   ScheduleInterval.daily: 'daily',
@@ -357,27 +334,29 @@ CommitMessage _$CommitMessageFromJson(Map json) => $checkedCreate(
           prefix: $checkedConvert('prefix', (v) => v as String?),
           prefixDevelopment:
               $checkedConvert('prefix-development', (v) => v as String?),
-          include: $checkedConvert('include', (v) => v as String? ?? 'scope'),
+          include: $checkedConvert(
+              'include',
+              (v) =>
+                  $enumDecodeNullable(_$CommitMessageIncludeEnumMap, v) ??
+                  CommitMessageInclude.scope),
         );
         return val;
       },
       fieldKeyMap: const {'prefixDevelopment': 'prefix-development'},
     );
 
-Map<String, dynamic> _$CommitMessageToJson(CommitMessage instance) {
-  final val = <String, dynamic>{};
+Map<String, dynamic> _$CommitMessageToJson(CommitMessage instance) =>
+    <String, dynamic>{
+      if (instance.prefix case final value?) 'prefix': value,
+      if (instance.prefixDevelopment case final value?)
+        'prefix-development': value,
+      if (_$CommitMessageIncludeEnumMap[instance.include] case final value?)
+        'include': value,
+    };
 
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('prefix', instance.prefix);
-  writeNotNull('prefix-development', instance.prefixDevelopment);
-  writeNotNull('include', instance.include);
-  return val;
-}
+const _$CommitMessageIncludeEnumMap = {
+  CommitMessageInclude.scope: 'scope',
+};
 
 Ignore _$IgnoreFromJson(Map json) => $checkedCreate(
       'Ignore',
@@ -408,22 +387,13 @@ Ignore _$IgnoreFromJson(Map json) => $checkedCreate(
       },
     );
 
-Map<String, dynamic> _$IgnoreToJson(Ignore instance) {
-  final val = <String, dynamic>{
-    'dependency-name': instance.dependencyName,
-  };
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('versions', instance.versions);
-  writeNotNull('update-types',
-      instance.updateTypes?.map((e) => _$UpdateTypeEnumMap[e]!).toList());
-  return val;
-}
+Map<String, dynamic> _$IgnoreToJson(Ignore instance) => <String, dynamic>{
+      'dependency-name': instance.dependencyName,
+      if (instance.versions case final value?) 'versions': value,
+      if (instance.updateTypes?.map((e) => _$UpdateTypeEnumMap[e]!).toList()
+          case final value?)
+        'update-types': value,
+    };
 
 const _$UpdateTypeEnumMap = {
   UpdateType.major: 'version-update:semver-major',

--- a/test/src/commands/command_base_test.dart
+++ b/test/src/commands/command_base_test.dart
@@ -67,6 +67,11 @@ class _GroupsOptionCommand extends _TestCommand with GroupsOption {
   _GroupsOptionCommand({required super.logger});
 }
 
+class _CommitMessageOptionCommand extends _TestCommand
+    with CommitMessageOption {
+  _CommitMessageOptionCommand({required super.logger});
+}
+
 void main() {
   late Logger logger;
 
@@ -485,6 +490,114 @@ The package ecosystems to ignore when searching for packages. Defaults to none.'
       expect(command.ecosystems, [
         PackageEcosystem.githubActions,
       ]);
+    });
+  });
+
+  group('CommitMessageOption', () {
+    test('adds options', () {
+      final command = _CommitMessageOptionCommand(logger: logger);
+
+      expect(
+        command.argParser.options['commit-message-prefix'],
+        isA<Option>().having((e) => e.help, 'help',
+            'Prefix for all commit messages and pull request titles. '),
+      );
+
+      expect(
+        command.argParser.options['commit-message-prefix-development'],
+        isA<Option>().having(
+          (e) => e.help,
+          'help',
+          'Prefix used only for commit messages that update dependencies '
+              'in the Development dependency group. Supported by: bundler, '
+              'composer, mix, maven, npm, pip, and uv. Behaves like '
+              '--commit-message-prefix for all other cases.',
+        ),
+      );
+
+      expect(
+        command.argParser.options['commit-message-include'],
+        isA<Option>()
+            .having(
+          (e) => e.help,
+          'help',
+          'Follow the commit message prefix with additional information. '
+              'Currently only "scope" is supported, which appends the type of '
+              'dependencies updated in the commit: deps or deps-dev.',
+        )
+            .having((e) => e.allowed, 'allowed', ['scope']),
+      );
+    });
+
+    test('returns null when no options are provided', () {
+      final command = _CommitMessageOptionCommand(logger: logger);
+      command.argResults = command.argParser.parse([]);
+      expect(command.commitMessage, isNull);
+    });
+
+    test('sets commit message with prefix only', () {
+      final command = _CommitMessageOptionCommand(logger: logger);
+      command.argResults = command.argParser.parse(
+        ['--commit-message-prefix', 'chore(deps):'],
+      );
+      expect(
+        command.commitMessage,
+        const CommitMessage(
+          prefix: 'chore(deps):',
+          prefixDevelopment: null,
+          include: null,
+        ),
+      );
+    });
+
+    test('sets commit message with prefix-development only', () {
+      final command = _CommitMessageOptionCommand(logger: logger);
+      command.argResults = command.argParser.parse(
+        ['--commit-message-prefix-development', 'chore(deps-dev):'],
+      );
+      expect(
+        command.commitMessage,
+        const CommitMessage(
+          prefix: null,
+          prefixDevelopment: 'chore(deps-dev):',
+          include: null,
+        ),
+      );
+    });
+
+    test('sets commit message with include only', () {
+      final command = _CommitMessageOptionCommand(logger: logger);
+      command.argResults = command.argParser.parse(
+        ['--commit-message-include', 'scope'],
+      );
+      expect(
+        command.commitMessage,
+        const CommitMessage(
+          prefix: null,
+          prefixDevelopment: null,
+          include: CommitMessageInclude.scope,
+        ),
+      );
+    });
+
+    test('sets commit message with all options', () {
+      final command = _CommitMessageOptionCommand(logger: logger);
+      command.argResults = command.argParser.parse([
+        '--commit-message-prefix',
+        'chore(deps):',
+        '--commit-message-prefix-development',
+        'chore(deps-dev):',
+        '--commit-message-include',
+        'scope',
+      ]);
+      expect(
+        command.commitMessage,
+        const CommitMessage(
+          prefix: 'chore(deps):',
+          prefixDevelopment: 'chore(deps-dev):',
+          include: CommitMessageInclude.scope,
+        ),
+      );
     });
   });
 

--- a/test/src/commands/create_command_test.dart
+++ b/test/src/commands/create_command_test.dart
@@ -18,22 +18,26 @@ Create or update the dependabot.yaml file in a repository. Will keep existing en
 
 
 Usage: depgen create [arguments]
--h, --help                 Print this usage information.
--e, --ecosystems           The package ecosystems to consider when searching for packages. Defaults to all available.
-                           [githubActions (default), docker (default), gitModules (default), bundler (default), cargo (default), composer (default), elm (default), gomod (default), gradle (default), hex (default), maven (default), npm (default), nuget (default), pip (default), pub (default), swift (default), terraform (default)]
-    --ignore-ecosystems    The package ecosystems to ignore when searching for packages. Defaults to none.
-                           [githubActions, docker, gitModules, bundler, cargo, composer, elm, gomod, gradle, hex, maven, npm, nuget, pip, pub, swift, terraform]
--S, --silent               Silences all output.
--V, --verbose              Show verbose output.
--I, --schedule-interval    The interval to check for updates on new update entries (does not affect existing ones).
-                           [daily, weekly (default), monthly]
-    --target-branch        The target branch to create pull requests against.
-    --labels               Labels to add to the pull requests.
-    --milestone            The milestone to add to the pull requests. Must be a number.
-    --[no-]use-groups      Use groups on update entries.
-                           (defaults to on)
--i, --ignore-paths         Paths to ignore when searching for packages. Example: "__brick__/**"
--r, --repo-root            Path to the repository root. If omitted, the command will search for the closest git repository root from the current working directory.
+-h, --help                                 Print this usage information.
+-e, --ecosystems                           The package ecosystems to consider when searching for packages. Defaults to all available.
+                                           [githubActions (default), docker (default), gitModules (default), bundler (default), cargo (default), composer (default), elm (default), gomod (default), gradle (default), hex (default), maven (default), npm (default), nuget (default), pip (default), pub (default), swift (default), terraform (default)]
+    --ignore-ecosystems                    The package ecosystems to ignore when searching for packages. Defaults to none.
+                                           [githubActions, docker, gitModules, bundler, cargo, composer, elm, gomod, gradle, hex, maven, npm, nuget, pip, pub, swift, terraform]
+-S, --silent                               Silences all output.
+-V, --verbose                              Show verbose output.
+-I, --schedule-interval                    The interval to check for updates on new update entries (does not affect existing ones).
+                                           [daily, weekly (default), monthly]
+    --target-branch                        The target branch to create pull requests against.
+    --labels                               Labels to add to the pull requests.
+    --milestone                            The milestone to add to the pull requests. Must be a number.
+    --[no-]use-groups                      Use groups on update entries.
+                                           (defaults to on)
+    --commit-message-prefix                Prefix for all commit messages and pull request titles. 
+    --commit-message-prefix-development    Prefix used only for commit messages that update dependencies in the Development dependency group. Supported by: bundler, composer, mix, maven, npm, pip, and uv. Behaves like --commit-message-prefix for all other cases.
+    --commit-message-include               Follow the commit message prefix with additional information. Currently only "scope" is supported, which appends the type of dependencies updated in the commit: deps or deps-dev.
+                                           [scope]
+-i, --ignore-paths                         Paths to ignore when searching for packages. Example: "__brick__/**"
+-r, --repo-root                            Path to the repository root. If omitted, the command will search for the closest git repository root from the current working directory.
 
 Run "depgen help" to see global options.''';
 
@@ -64,6 +68,7 @@ void main() {
       expect(command, isA<LabelsOption>());
       expect(command, isA<MilestoneOption>());
       expect(command, isA<GroupsOption>());
+      expect(command, isA<CommitMessageOption>());
       expect(command, isA<IgnorePathsOption>());
       expect(command, isA<RepositoryRootOption>());
     });

--- a/test/src/dependabot_yaml/spec_test.dart
+++ b/test/src/dependabot_yaml/spec_test.dart
@@ -143,7 +143,7 @@ void main() {
               commitMessage: CommitMessage(
                 prefix: 'chore(deps):',
                 prefixDevelopment: 'chore(deps-dev):',
-                include: 'scope',
+                include: CommitMessageInclude.scope,
               ),
               ignore: [
                 Ignore(
@@ -216,7 +216,7 @@ void main() {
                   commitMessage: CommitMessage(
                     prefix: 'chore(deps):',
                     prefixDevelopment: 'chore(deps-dev):',
-                    include: 'scope',
+                    include: CommitMessageInclude.scope,
                   ),
                   ignore: [
                     Ignore(


### PR DESCRIPTION
## Description

Adds the `--commit-message-prefix`, `--commit-message-prefix-development` and `--commit-message-include` options to the create command.

**Reference:** https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#commit-message--


